### PR TITLE
fix wowchemy path

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -22,8 +22,8 @@ removePathAccents: true
 
 module:
   imports:
-    - path: github.com/wowchemy/wowchemy-hugo-modules/wowchemy-cms/v5
-    - path: github.com/wowchemy/wowchemy-hugo-modules/wowchemy/v5
+    - path: github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-cms/v5
+    - path: github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy/v5
 
 ############################
 ## ADVANCED


### PR DESCRIPTION
The path for wowchemy modules on github has changed. This PR attempt to fix and update the theme to latest version.
If it don't work, consider start from scratch.